### PR TITLE
Start and stop amplicon positions in csv output

### DIFF
--- a/src/primerpairlist.cpp
+++ b/src/primerpairlist.cpp
@@ -335,19 +335,24 @@ namespace DeGenPrime
 
 	string PrimerPairList::CreateCSV(DataSequence fwd, DataSequence rev)
 	{
-		string ret = "Pair #,Forward,Reverse,Amplicon,Temp. Diff\n";
+		string ret = "Pair #,Forward,Reverse,Amplicon,Temp. Diff,Fwd. Start,Rev. End\n";
+		int N = fwd.size();
 		for(size_t i = 0;i < _pairs.size();i++)
 		{
 			DataSequence fwdSub = fwd.SubSeq(_pairs[i].GetForward().Index(), _pairs[i].GetForward().Length());
 			DataSequence revSub = rev.SubSeq(_pairs[i].GetReverse().Index(), _pairs[i].GetReverse().Length());
-
+			
+			int fwdStart = _pairs[i].GetForward().Index() + 1;
+			int revEnd = N - _pairs[i].GetReverse().Index();
+			
 			ret += to_string(i + 1) + ",";
 			ret += fwdSub.Codes() + ",";
 			ret += revSub.Codes() + ",";
 			ret += to_string(_pairs[i].AmpSize()) + ",";
-			ret += to_string(_pairs[i].TempDiff()) + "\n";
+			ret += to_string(_pairs[i].TempDiff()) + ",";
+			ret += to_string(fwdStart) + ",";
+			ret += to_string(revEnd) + "\n";
 		}
-
 		return ret;
 	}
 


### PR DESCRIPTION
I was constructing primers for nested PCR recently and found your package, which came in really handy. However, for the output primers, I couldn't obtain their exact amplicon coordinates (alignment-wise), which is crucial because, in nested PCR, the inner amplicon should be inside the outer one. Therefore, I decided to contribute a small modification that adds two columns to the output CSV, indicating the 1-based starting and ending positions of each amplicon.